### PR TITLE
toggletrace option for legend implemented

### DIFF
--- a/src/components/legend/attributes.js
+++ b/src/components/legend/attributes.js
@@ -72,6 +72,12 @@ module.exports = {
             'Sets the amount of vertical space (in px) between legend groups.'
         ].join(' ')
     },
+    tracetoggle: {
+        valType: 'boolean',
+        dflt: true,
+        role: 'info',
+        description: 'Enable toggle trace when legend is clicked.'
+    },
     x: {
         valType: 'number',
         min: -2,

--- a/src/components/legend/defaults.js
+++ b/src/components/legend/defaults.js
@@ -86,5 +86,6 @@ module.exports = function legendDefaults(layoutIn, layoutOut, fullData) {
     coerce('xanchor', defaultXAnchor);
     coerce('y', defaultY);
     coerce('yanchor', defaultYAnchor);
+    coerce('tracetoggle', true);
     Lib.noneOrAll(containerIn, containerOut, ['x', 'y']);
 };

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -375,6 +375,8 @@ function drawTexts(g, gd) {
 }
 
 function setupTraceToggle(g, gd) {
+    console.log(gd._fullLayout.legend)
+    if (!gd._fullLayout.legend.tracetoggle) return;
     var hiddenSlices = gd._fullLayout.hiddenlabels ?
         gd._fullLayout.hiddenlabels.slice() :
         [];

--- a/test/image/export_test.js
+++ b/test/image/export_test.js
@@ -19,6 +19,7 @@ var DEFAULT_LIST = ['0', 'geo_first', 'gl3d_z-range', 'text_export'];
 // minimum satisfactory file size
 var MIN_SIZE = 100;
 
+
 /**
  *  Image export test script.
  *

--- a/test/image/mocks/legend_toggletrace.json
+++ b/test/image/mocks/legend_toggletrace.json
@@ -1,0 +1,62 @@
+{
+  "data": [
+    {
+      "x": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "y": [
+        0,
+        3,
+        6,
+        4,
+        5,
+        2,
+        3,
+        5,
+        4
+      ],
+      "name": "Blue Trace",
+      "type": "scatter"
+    },
+    {
+      "x": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "y": [
+        0,
+        4,
+        7,
+        8,
+        3,
+        6,
+        3,
+        3,
+        4
+      ],
+      "name": "Orange Trace",
+      "type": "scatter"
+    }
+  ],
+  "layout": {
+    "showlegend": true,
+    "legend": {
+      "tracetoggle": false
+    }
+  }
+}


### PR DESCRIPTION
Allows to add an option in legend config: 
`"legend": {
      "tracetoggle": false
 }`
to disable hiding of traces. Defaults to true.
